### PR TITLE
[0.x] Bugfix: Fix class name for initialization

### DIFF
--- a/index.php
+++ b/index.php
@@ -2,5 +2,5 @@
 
 require __DIR__.'/vendor/autoload.php';
 
-$proxy = new CachingProxy\ProxyServer();
+$proxy = new Phoxy\ProxyServer();
 $proxy->handleRequest();

--- a/src/ProxyServer.php
+++ b/src/ProxyServer.php
@@ -83,6 +83,7 @@ class ProxyServer
 
     private function checkFilterUrl(string $url): bool
     {
+        $url = $this->standardUrl($url);
         $host = parse_url($url, PHP_URL_HOST);
 
         // Allow localhost for development
@@ -95,6 +96,15 @@ class ProxyServer
         }
 
         return true;
+    }
+
+    private function standardUrl(string $url): string
+    {
+        if (preg_match('/^https?:\/\//', $url)) {
+            return $url;
+        }
+
+        return 'https://' . $url;
     }
 
     /**


### PR DESCRIPTION
Add mehtod to generate standard `URL` string for host